### PR TITLE
Add config example and database schema for runs and PRs tracking

### DIFF
--- a/shared/config.example.env
+++ b/shared/config.example.env
@@ -1,0 +1,6 @@
+DB_PATH=./cursor_agents.db
+# GitHub (optional, but recommended for PR enrichment)
+GITHUB_TOKEN=
+# Scoring knobs (optional)
+MINUTES_LONG_RUN=18
+HIGH_CHURN_LINES=500

--- a/shared/schema.sql
+++ b/shared/schema.sql
@@ -1,0 +1,46 @@
+-- shared/schema.sql
+CREATE TABLE IF NOT EXISTS runs (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  prompt TEXT,
+  status TEXT,
+  repo TEXT,
+  branch TEXT,
+  created_at TEXT,
+  updated_at TEXT,
+  duration_seconds INTEGER,
+  pr_url TEXT,
+  details_url TEXT,
+  raw JSON
+);
+CREATE INDEX IF NOT EXISTS runs_updated ON runs(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS prs (
+  id TEXT PRIMARY KEY,              -- owner/repo#number
+  owner TEXT,
+  repo TEXT,
+  number INTEGER,
+  title TEXT,
+  author TEXT,
+  state TEXT,                       -- open/closed/merged
+  html_url TEXT,
+  created_at TEXT,
+  updated_at TEXT,
+  merged_at TEXT,
+  additions INTEGER,
+  deletions INTEGER,
+  changed_files INTEGER,
+  draft INTEGER,                    -- 0/1
+  review_count INTEGER,
+  ci_status TEXT,                   -- success/failure/pending/unknown
+  has_tests INTEGER,                -- 0/1 heuristic
+  doc_touch_ratio REAL,             -- 0..1
+  diff_stats JSON                   -- raw enrichment cache
+);
+CREATE INDEX IF NOT EXISTS prs_updated ON prs(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS run_prs (
+  run_id TEXT,
+  pr_id TEXT,
+  PRIMARY KEY (run_id, pr_id)
+);


### PR DESCRIPTION
I created the two files exactly as specified.

shared/config.example.env
shared/schema.sql
What you need to do:

Copy the example to your real env file:
cp shared/config.example.env .env
Edit .env:
DB_PATH points to a local SQLite file. Example: DB_PATH=/workspace/cursor_agents.db
GITHUB_TOKEN is optional. Leave it empty for now; add it later if you want PR enrichment.
Notes:

You don’t need a hosted database. SQLite is just a single file on disk pointed to by DB_PATH.
No token is needed to test scraping and basic functionality. Add GITHUB_TOKEN only if you want extra PR details.
Status:

Added shared/config.example.env with DB_PATH and optional GITHUB_TOKEN.
Added shared/schema.sql matching the doc’s schema (tables: runs, prs, run_prs; indexes on updated_at).